### PR TITLE
fixed double-incrementing bug in JobProcessingActor

### DIFF
--- a/core/app/actors/JobProcessingActor.java
+++ b/core/app/actors/JobProcessingActor.java
@@ -66,7 +66,6 @@ public class JobProcessingActor extends UntypedActor {
                             } catch (Exception e) {
                                 System.out.println(e);
                                 skipped++;
-                                completed++;
                                 getSender().tell(new StatusUpdate(completed, skipped, total), getSelf());
                                 return;
                             }


### PR DESCRIPTION
We were incrementing `completed` twice if the annotator skipped an instance.
